### PR TITLE
Feat/add mcp server/cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,18 @@ type StreamableClientTransport struct {
 
 Config lives at `~/.abox/config.yaml` (same pattern as `~/.claude`, `~/.codex`). First `abox` run creates `~/.abox/` (mode 0700) and a default `config.yaml` if they are missing. Credentials are `~/.abox/credentials.env`.
 
+Add a Streamable HTTP server without editing YAML by hand. `--mode` is required:
+
+```bash
+# Direct: ABox dials the server. Token optional.
+abox mcp add --mode direct --credential-env GITHUB_MCP_TOKEN github https://api.githubcopilot.com/mcp/
+
+# Agentgateway: ABox dials the gateway only. No token; auth is on the gateway.
+abox mcp add --mode agentgateway agw https://agw.example/mcp
+```
+
+`abox mcp login <name>` runs host OAuth (or saves a PAT) for a server that already exists in config. `/mcp` in the TUI pastes a Bearer for a configured server.
+
 One guest client. Every remote MCP is a Streamable HTTP `url`. Direct GitHub and an agentgateway virtual MCP are the same field; only `connectivity.mode` changes the policy. `credential_env` is optional (omit when the server needs no Bearer).
 
 - `direct` — guest may dial every `mcp_servers` URL.

--- a/README.md
+++ b/README.md
@@ -297,20 +297,6 @@ and when thinking about what language to write a Harness in, you should think ab
 
 Because of the above, Go or Rust are naturally great languages. Because I like Go, I went with Go. No other reason as it would've been perfectly suitable in Rust. I might even have an Agent do a Rust version for comparison at some point.
 
-<<<<<<< HEAD
-## What is not done yet
-
-Compaction, checkpoint/rollback/fork, stdio MCP, host broker, and resource
-acceptance. See `PLAN.md`. Streamable HTTP MCP is in; isolation stays Planned.
-
-## Security
-
-Do not describe this build as verified isolation. The device plan is
-allowlisted (no guest NIC, no host-path virtio-fs, TSI flags zero). Claims
-stay Planned until the hardware suite in `PLAN.md` §21.4 passes.
-
-=======
->>>>>>> 6cedf71a1b349b246aea20d467b0851db8030a45
 ## Whats Currently In Place
 
 ```

--- a/cmd/abox/main.go
+++ b/cmd/abox/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/AdminTurnedDevOps/ABox/internal/config"
@@ -193,17 +194,52 @@ func currentSecrets(cfg config.File) map[string]string {
 
 func runMCP(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: abox mcp login <server-name>")
+		return fmt.Errorf("usage: abox mcp add --mode <direct|agentgateway> [--credential-env NAME] <name> <url>\n       abox mcp login <server-name>")
 	}
 	switch args[0] {
+	case "add":
+		return mcpAdd(args[1:])
 	case "login":
 		if len(args) < 2 {
 			return fmt.Errorf("usage: abox mcp login <server-name>")
 		}
 		return mcpLogin(args[1])
 	default:
-		return fmt.Errorf("unknown mcp command %q", args[0])
+		return fmt.Errorf("unknown mcp command %q\nusage: abox mcp add --mode <direct|agentgateway> <name> <url>", args[0])
 	}
+}
+
+func mcpAdd(args []string) error {
+	fs := flag.NewFlagSet("abox mcp add", flag.ContinueOnError)
+	mode := fs.String("mode", "", "direct or agentgateway")
+	cred := fs.String("credential-env", "", "optional env var holding a Bearer token")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	rest := fs.Args()
+	if strings.TrimSpace(*mode) == "" || len(rest) != 2 {
+		return fmt.Errorf("usage: abox mcp add --mode <direct|agentgateway> [--credential-env NAME] <name> <url>")
+	}
+	cfg, path, err := config.Load()
+	if err != nil {
+		return err
+	}
+	srv := config.MCPServer{
+		Name:          rest[0],
+		URL:           rest[1],
+		CredentialEnv: strings.TrimSpace(*cred),
+	}
+	if err := cfg.AddMCPServer(*mode, srv); err != nil {
+		return err
+	}
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+	fmt.Printf("added %s (%s) %s\n  config %s\n", srv.Name, *mode, srv.URL, path)
+	if *mode == "direct" && srv.CredentialEnv != "" {
+		fmt.Printf("  set %s or run: abox mcp login %s\n", srv.CredentialEnv, srv.Name)
+	}
+	return nil
 }
 
 func mcpLogin(name string) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -230,6 +230,65 @@ func (c File) ResolvedMCPServers() ([]MCPServer, error) {
 	return c.MCPServers, nil
 }
 
+// AddMCPServer records a Streamable HTTP MCP server and sets connectivity.mode.
+// mode must be "direct" or "agentgateway". Same name upserts. Agentgateway
+// with required enforcement keeps exactly one origin.
+func (c *File) AddMCPServer(mode string, srv MCPServer) error {
+	switch mode {
+	case "direct", "agentgateway":
+	default:
+		return fmt.Errorf("mode must be direct or agentgateway")
+	}
+	if err := srv.validate(); err != nil {
+		return err
+	}
+	c.Connectivity.Mode = mode
+	if mode == "agentgateway" {
+		if c.Connectivity.Enforcement == "" {
+			c.Connectivity.Enforcement = "required"
+		}
+		if c.Connectivity.Enforcement == "required" {
+			for _, existing := range c.MCPServers {
+				if existing.Name != srv.Name {
+					return fmt.Errorf("agentgateway required allows exactly one mcp_servers entry (already have %q)", existing.Name)
+				}
+			}
+			c.MCPServers = []MCPServer{srv}
+			return c.Validate()
+		}
+	}
+	for i, existing := range c.MCPServers {
+		if existing.Name == srv.Name {
+			c.MCPServers[i] = srv
+			return c.Validate()
+		}
+	}
+	c.MCPServers = append(c.MCPServers, srv)
+	return c.Validate()
+}
+
+func (c File) Save() error {
+	if err := c.Validate(); err != nil {
+		return err
+	}
+	if err := EnsureLayout(); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	path := Path()
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o600)
+}
+
 func TokenEnv(server MCPServer) string {
 	if server.CredentialEnv != "" {
 		return server.CredentialEnv

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,8 +105,11 @@ func EnsureLayout() error {
 	if err := os.MkdirAll(SessionRoot(), 0o700); err != nil {
 		return fmt.Errorf("create sessions dir: %w", err)
 	}
-	if err := os.MkdirAll(ImageDir(), 0o700); err != nil {
+	if err := os.MkdirAll(filepath.Join(Dir(), "images"), 0o700); err != nil {
 		return fmt.Errorf("create images dir: %w", err)
+	}
+	if err := seedFromLegacy(); err != nil {
+		return err
 	}
 	path := Path()
 	if exists(path) {
@@ -118,6 +121,32 @@ func EnsureLayout() error {
 	}
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func seedFromLegacy() error {
+	home := homeDir()
+	if home == "" {
+		return nil
+	}
+	legacy := filepath.Join(home, "Library", "Application Support", "ABox")
+	for _, name := range []string{"config.yaml", "credentials.env"} {
+		dst := filepath.Join(Dir(), name)
+		if exists(dst) {
+			continue
+		}
+		src := filepath.Join(legacy, name)
+		data, err := os.ReadFile(src)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return err
+		}
+		if err := os.WriteFile(dst, data, 0o600); err != nil {
+			return fmt.Errorf("seed %s: %w", name, err)
+		}
 	}
 	return nil
 }
@@ -333,9 +362,7 @@ func exists(path string) bool {
 	return err == nil
 }
 
-// Dir is ~/.abox, matching other CLI harnesses. ABOX_HOME overrides.
-// If ~/.abox does not exist yet but the old macOS Application Support
-// tree does, that legacy path is used so existing installs keep working.
+// Dir is always ~/.abox unless ABOX_HOME is set. First run creates it.
 func Dir() string {
 	if override := strings.TrimSpace(os.Getenv("ABOX_HOME")); override != "" {
 		return override
@@ -344,15 +371,7 @@ func Dir() string {
 	if home == "" {
 		return filepath.Join(".", "var", "abox")
 	}
-	modern := filepath.Join(home, ".abox")
-	legacy := filepath.Join(home, "Library", "Application Support", "ABox")
-	if exists(modern) {
-		return modern
-	}
-	if exists(legacy) {
-		return legacy
-	}
-	return modern
+	return filepath.Join(home, ".abox")
 }
 
 func AppSupportDir() string { return Dir() }
@@ -363,13 +382,13 @@ func CacheDir() string {
 
 func ImageDir() string {
 	modern := filepath.Join(Dir(), "images")
-	if exists(modern) {
+	if exists(filepath.Join(modern, "abox-guest.raw")) {
 		return modern
 	}
 	home := homeDir()
 	if home != "" {
 		legacy := filepath.Join(home, "Library", "Caches", "ABox", "images")
-		if exists(legacy) {
+		if exists(filepath.Join(legacy, "abox-guest.raw")) {
 			return legacy
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -78,6 +78,70 @@ func TestEnsureLayoutCreatesHomeAndConfig(t *testing.T) {
 	}
 }
 
+func TestAddMCPServerDirect(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ABOX_HOME", "")
+	cfg := Defaults()
+	if err := cfg.AddMCPServer("direct", MCPServer{
+		Name:          "github",
+		URL:           "https://api.githubcopilot.com/mcp/",
+		CredentialEnv: "GITHUB_MCP_TOKEN",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Connectivity.Mode != "direct" || len(cfg.MCPServers) != 1 {
+		t.Fatalf("%#v", cfg)
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.MCPServers) != 1 || got.MCPServers[0].Name != "github" {
+		t.Fatalf("%#v", got.MCPServers)
+	}
+}
+
+func TestAddMCPServerAgentgateway(t *testing.T) {
+	cfg := Defaults()
+	if err := cfg.AddMCPServer("agentgateway", MCPServer{
+		Name: "agw",
+		URL:  "https://agw.example/mcp",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Connectivity.Mode != "agentgateway" {
+		t.Fatalf("mode %q", cfg.Connectivity.Mode)
+	}
+	if cfg.Connectivity.Enforcement != "required" {
+		t.Fatalf("enforcement %q", cfg.Connectivity.Enforcement)
+	}
+	if len(cfg.MCPServers) != 1 || cfg.MCPServers[0].CredentialEnv != "" {
+		t.Fatalf("%#v", cfg.MCPServers)
+	}
+}
+
+func TestAddMCPServerAgentgatewayRejectsSecondOrigin(t *testing.T) {
+	cfg := Defaults()
+	if err := cfg.AddMCPServer("agentgateway", MCPServer{Name: "agw", URL: "https://agw.example/mcp"}); err != nil {
+		t.Fatal(err)
+	}
+	err := cfg.AddMCPServer("agentgateway", MCPServer{Name: "github", URL: "https://api.githubcopilot.com/mcp/"})
+	if err == nil {
+		t.Fatal("expected second origin rejected")
+	}
+}
+
+func TestAddMCPServerRequiresKnownMode(t *testing.T) {
+	cfg := Defaults()
+	if err := cfg.AddMCPServer("stdio", MCPServer{Name: "x", URL: "https://example.com/mcp"}); err == nil {
+		t.Fatal("expected unknown mode rejected")
+	}
+}
+
 func TestEnsureLayoutDoesNotOverwriteConfig(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -34,6 +34,51 @@ func TestDirUsesDotAbox(t *testing.T) {
 	}
 }
 
+func TestDirIgnoresLegacyApplicationSupport(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ABOX_HOME", "")
+	legacy := filepath.Join(home, "Library", "Application Support", "ABox")
+	if err := os.MkdirAll(legacy, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "config.yaml"), []byte("connectivity:\n  mode: direct\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := Dir()
+	want := filepath.Join(home, ".abox")
+	if got != want {
+		t.Fatalf("Dir()=%q want %q", got, want)
+	}
+}
+
+func TestEnsureLayoutSeedsLegacyConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ABOX_HOME", "")
+	legacy := filepath.Join(home, "Library", "Application Support", "ABox")
+	if err := os.MkdirAll(legacy, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	body := []byte("connectivity:\n  mode: offline\n")
+	if err := os.WriteFile(filepath.Join(legacy, "config.yaml"), body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if !exists(filepath.Join(home, ".abox")) {
+		t.Fatal("expected ~/.abox")
+	}
+	got, err := os.ReadFile(Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(body) {
+		t.Fatalf("got %q", got)
+	}
+}
+
 func TestDirRespectsABOX_HOME(t *testing.T) {
 	override := t.TempDir()
 	t.Setenv("ABOX_HOME", override)


### PR DESCRIPTION
MCP support.

1. Direct connection to MCP servers
2. Pass traffic through agentgateway
3. Add an MCP server via the CLI