### PR TITLE
Remove abox --no-vm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,12 +181,6 @@ Headless agent loop (needs a VM and a provider key; the prompt is sent to the gu
 abox exec --prompt "list the repository files"
 ```
 
-Open the TUI without a VM. The agent will not run; `/provider` still works:
-
-```bash
-abox --no-vm
-```
-
 ## LLM Integration
 
 ## MCP Integration

--- a/cmd/abox/main.go
+++ b/cmd/abox/main.go
@@ -36,7 +36,6 @@ func run() error {
 	execFlag := fs.Bool("exec", false, "headless driver")
 	prompt := fs.String("prompt", "", "prompt for exec mode")
 	modelName := fs.String("model", "", "configured model profile name")
-	noVM := fs.Bool("no-vm", false, "do not start a microVM; tools fail closed")
 	probeVM := fs.Bool("probe-vm", false, "boot the guest and list files; no model call")
 	args := os.Args[1:]
 	execMode := false
@@ -90,49 +89,47 @@ func run() error {
 
 	var sb *runtime.Sandbox
 	vmState := "not-started"
-	if !*noVM {
-		image := cfg.Runtime.Image
-		if image == "" {
-			image = filepath.Join(config.ImageDir(), "abox-guest.raw")
-		}
-		mcpServers, err := cfg.ResolvedMCPServers()
-		if err != nil {
+	image := cfg.Runtime.Image
+	if image == "" {
+		image = filepath.Join(config.ImageDir(), "abox-guest.raw")
+	}
+	mcpServers, err := cfg.ResolvedMCPServers()
+	if err != nil {
+		return err
+	}
+	if err := runtime.Prepare(sess, image, sel, currentSecrets(cfg), mcpServers); err != nil {
+		if execMode {
 			return err
 		}
-		if err := runtime.Prepare(sess, image, sel, currentSecrets(cfg), mcpServers); err != nil {
-			if execMode {
+		fmt.Fprintf(os.Stderr, "abox: vm prepare: %v\n", err)
+		vmState = "unavailable"
+	} else {
+		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		defer cancel()
+		vcpu, ram := cfg.Resources.VCPU, cfg.Resources.RAMMiB
+		if vcpu == 0 {
+			vcpu = 1
+		}
+		if ram == 0 {
+			ram = 768
+		}
+		started, err := runtime.Start(ctx, sess, cfg.Runtime.VMMPath, vcpu, ram)
+		if err != nil {
+			if execMode && *prompt != "" {
+				return fmt.Errorf("start vm: %w", err)
+			}
+			fmt.Fprintf(os.Stderr, "abox: vm start: %v\n", err)
+			vmState = "failed"
+		} else {
+			sb = started
+			vmState = "ready"
+			defer sb.Stop()
+			archive, err := repository.ArchiveHEAD(snap.Root)
+			if err != nil {
 				return err
 			}
-			fmt.Fprintf(os.Stderr, "abox: vm prepare: %v\n", err)
-			vmState = "unavailable"
-		} else {
-			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
-			defer cancel()
-			vcpu, ram := cfg.Resources.VCPU, cfg.Resources.RAMMiB
-			if vcpu == 0 {
-				vcpu = 1
-			}
-			if ram == 0 {
-				ram = 768
-			}
-			started, err := runtime.Start(ctx, sess, cfg.Runtime.VMMPath, vcpu, ram)
-			if err != nil {
-				if execMode && *prompt != "" {
-					return fmt.Errorf("start vm: %w", err)
-				}
-				fmt.Fprintf(os.Stderr, "abox: vm start: %v\n", err)
-				vmState = "failed"
-			} else {
-				sb = started
-				vmState = "ready"
-				defer sb.Stop()
-				archive, err := repository.ArchiveHEAD(snap.Root)
-				if err != nil {
-					return err
-				}
-				if err := sb.TransferArchive(context.Background(), archive); err != nil {
-					fmt.Fprintf(os.Stderr, "abox: repo transfer: %v\n", err)
-				}
+			if err := sb.TransferArchive(context.Background(), archive); err != nil {
+				fmt.Fprintf(os.Stderr, "abox: repo transfer: %v\n", err)
 			}
 		}
 	}


### PR DESCRIPTION
The agent loop only runs in the guest, so a TUI without a VM cannot send prompts or call tools. Host /provider and mcp add/login already cover config without booting a microVM.