### PR TITLE
type and tool refactor

### DIFF
--- a/cmd/abox-guest/main.go
+++ b/cmd/abox-guest/main.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/AdminTurnedDevOps/ABox/internal/agent"
+	"github.com/AdminTurnedDevOps/ABox/internal/config"
 	"github.com/AdminTurnedDevOps/ABox/internal/guest/egress"
 	guestmcp "github.com/AdminTurnedDevOps/ABox/internal/guest/mcp"
 	"github.com/AdminTurnedDevOps/ABox/internal/guest/tools"
@@ -53,7 +54,7 @@ func run() error {
 		fmt.Fprintf(os.Stderr, "abox-guest: mcp: %v\n", err)
 	}
 	defer mcpMgr.Close()
-	loop := &agent.Loop{Model: agent.ModelFromGuest(cfg.Model), Repo: repo, MCP: mcpMgr, ContextFile: agent.DefaultContextFile}
+	loop := &agent.Loop{Model: config.ModelFromGuest(cfg.Model), Repo: repo, MCP: mcpMgr, ContextFile: agent.DefaultContextFile}
 	if err := loop.LoadContext(); err != nil {
 		fmt.Fprintf(os.Stderr, "abox-guest: context: %v\n", err)
 	}
@@ -158,65 +159,8 @@ func handle(loop *agent.Loop, repo tools.Repo, mcpMgr *guestmcp.Manager, archive
 			break
 		}
 		applySecrets(p.Secrets)
-		loop.Model = agent.ModelFromGuest(p.Model)
+		loop.Model = config.ModelFromGuest(p.Model)
 		out.Result, _ = protocol.EncodeParams(map[string]bool{"ok": true})
-	case "list_files":
-		p, e := protocol.DecodeParams[protocol.ListFilesParams](req.Params)
-		if e != nil {
-			err = e
-			break
-		}
-		paths, e := repo.List(p.Path, p.Depth, p.Limit)
-		if e != nil {
-			err = e
-			break
-		}
-		out.Result, _ = protocol.EncodeParams(protocol.ListFilesResult{Paths: paths})
-	case "read_file":
-		p, e := protocol.DecodeParams[protocol.ReadFileParams](req.Params)
-		if e != nil {
-			err = e
-			break
-		}
-		content, bin, trunc, e := repo.Read(p.Path, p.MaxBytes)
-		if e != nil {
-			err = e
-			break
-		}
-		out.Result, _ = protocol.EncodeParams(protocol.ReadFileResult{Content: content, Binary: bin, Trunc: trunc})
-	case "search":
-		p, e := protocol.DecodeParams[protocol.SearchParams](req.Params)
-		if e != nil {
-			err = e
-			break
-		}
-		matches, e := repo.Search(p.Query, p.Path, p.Limit)
-		if e != nil {
-			err = e
-			break
-		}
-		out.Result, _ = protocol.EncodeParams(protocol.SearchResult{Matches: matches})
-	case "apply_patch":
-		p, e := protocol.DecodeParams[protocol.ApplyPatchParams](req.Params)
-		if e != nil {
-			err = e
-			break
-		}
-		output, e := repo.ApplyPatch(p.Patch)
-		out.Result, _ = protocol.EncodeParams(protocol.ApplyPatchResult{OK: e == nil, Output: output})
-		err = e
-	case "run_command":
-		p, e := protocol.DecodeParams[protocol.RunCommandParams](req.Params)
-		if e != nil {
-			err = e
-			break
-		}
-		timeout := time.Duration(p.Timeout) * time.Second
-		exit, stdout, stderr, dur, trunc, e := repo.Run(p.Command, p.WorkDir, timeout, tools.DefaultMaxOutput)
-		out.Result, _ = protocol.EncodeParams(protocol.RunCommandResult{
-			ExitCode: exit, Stdout: stdout, Stderr: stderr, Duration: dur.String(), Trunc: trunc,
-		})
-		err = e
 	case "archive_chunk":
 		p, e := protocol.DecodeParams[protocol.ArchiveChunkParams](req.Params)
 		if e != nil {
@@ -262,6 +206,14 @@ func handle(loop *agent.Loop, repo tools.Repo, mcpMgr *guestmcp.Manager, archive
 		_ = loop.SaveContext()
 		out.Result, _ = protocol.EncodeParams(map[string]bool{"ok": true})
 	default:
+		if tools.IsBuiltin(req.Method) {
+			var result any
+			result, err = repo.CallBuiltin(req.Method, req.Params, 0)
+			if result != nil {
+				out.Result, _ = protocol.EncodeParams(result)
+			}
+			break
+		}
 		err = fmt.Errorf("unknown method %q", req.Method)
 	}
 	if err != nil {
@@ -316,7 +268,7 @@ func parseGuestConfig(data []byte) (protocol.GuestConfig, error) {
 		return cfg, err
 	}
 	if cfg.RepoDir == "" {
-		cfg.RepoDir = "/work/repo"
+		cfg.RepoDir = protocol.GuestRepoDir
 	}
 	if cfg.VsockPort == 0 {
 		cfg.VsockPort = protocol.RPCPort
@@ -329,7 +281,7 @@ func prepMounts() {
 	_ = os.MkdirAll("/sys", 0o755)
 	_ = os.MkdirAll("/dev", 0o755)
 	_ = os.MkdirAll("/tmp", 0o1777)
-	_ = os.MkdirAll("/work/repo", 0o755)
+	_ = os.MkdirAll(protocol.GuestRepoDir, 0o755)
 	_ = os.MkdirAll("/var/lib/abox", 0o755)
 	_ = mountIfNeeded("proc", "/proc")
 	_ = mountIfNeeded("sysfs", "/sys")

--- a/cmd/abox-vmm/main.go
+++ b/cmd/abox-vmm/main.go
@@ -25,18 +25,7 @@ func run() error {
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return fmt.Errorf("parse config: %w", err)
 	}
-	if cfg.VCPU == 0 {
-		cfg.VCPU = 1
-	}
-	if cfg.RAMMiB == 0 {
-		cfg.RAMMiB = 768
-	}
-	if cfg.VsockPort == 0 {
-		cfg.VsockPort = 1024
-	}
-	if cfg.ExecPath == "" {
-		cfg.ExecPath = "/usr/local/bin/abox-guest"
-	}
+	cfg.ApplyDefaults()
 	if cfg.RootDisk == "" || cfg.RPCSocket == "" {
 		return fmt.Errorf("root_disk and rpc_socket are required")
 	}

--- a/cmd/abox/main.go
+++ b/cmd/abox/main.go
@@ -113,13 +113,13 @@ func run() error {
 	vmState := "not-started"
 	image := cfg.Runtime.Image
 	if image == "" {
-		image = filepath.Join(config.ImageDir(), "abox-guest.raw")
+		image = config.GuestImagePath()
 	}
 	mcpServers, err := cfg.ResolvedMCPServers()
 	if err != nil {
 		return err
 	}
-	if err := runtime.Prepare(sess, image, sel, currentSecrets(cfg), mcpServers, *resume); err != nil {
+	if err := runtime.Prepare(sess, image, sel, cfg.SecretsFromEnv(), mcpServers, *resume); err != nil {
 		if execMode {
 			return err
 		}
@@ -128,13 +128,7 @@ func run() error {
 	} else {
 		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 		defer cancel()
-		vcpu, ram := cfg.Resources.VCPU, cfg.Resources.RAMMiB
-		if vcpu == 0 {
-			vcpu = 1
-		}
-		if ram == 0 {
-			ram = 768
-		}
+		vcpu, ram := cfg.Resources.Resolved()
 		started, err := runtime.Start(ctx, sess, cfg.Runtime.VMMPath, vcpu, ram)
 		if err != nil {
 			if execMode && *prompt != "" {
@@ -240,26 +234,6 @@ func loadResumeSession(wd, id string) (*session.Session, error) {
 		roots = append(roots, top)
 	}
 	return session.LatestForRepo(roots...)
-}
-
-func currentSecrets(cfg config.File) map[string]string {
-	out := map[string]string{}
-	for _, name := range []string{"XAI_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"} {
-		if v := os.Getenv(name); v != "" {
-			out[name] = v
-		}
-	}
-	servers, err := cfg.ResolvedMCPServers()
-	if err != nil {
-		return out
-	}
-	for _, s := range servers {
-		name := config.TokenEnv(s)
-		if v := os.Getenv(name); v != "" {
-			out[name] = v
-		}
-	}
-	return out
 }
 
 func runMCP(args []string) error {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -37,26 +37,12 @@ type Loop struct {
 }
 
 func BuiltinTools() []provider.ToolSchema {
-	obj := func(props map[string]any) map[string]any {
-		return map[string]any{"type": "object", "properties": props}
+	specs := tools.BuiltinSpecs()
+	out := make([]provider.ToolSchema, len(specs))
+	for i, s := range specs {
+		out[i] = provider.ToolSchema{Name: s.Name, Description: s.Description, Parameters: s.Parameters}
 	}
-	return []provider.ToolSchema{
-		{Name: "list_files", Description: "List paths in the guest repository", Parameters: obj(map[string]any{
-			"path": map[string]any{"type": "string"},
-		})},
-		{Name: "read_file", Description: "Read a file in the guest repository", Parameters: obj(map[string]any{
-			"path": map[string]any{"type": "string"},
-		})},
-		{Name: "search", Description: "Search the guest repository", Parameters: obj(map[string]any{
-			"query": map[string]any{"type": "string"},
-		})},
-		{Name: "apply_patch", Description: "Apply a unified diff in the guest repository", Parameters: obj(map[string]any{
-			"patch": map[string]any{"type": "string"},
-		})},
-		{Name: "run_command", Description: "Run a shell command in the guest", Parameters: obj(map[string]any{
-			"command": map[string]any{"type": "string"},
-		})},
-	}
+	return out
 }
 
 func (l *Loop) emit(e protocol.AgentEvent) {
@@ -284,68 +270,12 @@ func (l *Loop) execTool(ctx context.Context, ev provider.Event) (string, error) 
 		}
 		return l.MCP.Call(ctx, server, tool, json.RawMessage(ev.ToolArgs))
 	}
-	switch ev.ToolName {
-	case "list_files":
-		var args struct {
-			Path string `json:"path"`
-		}
-		_ = json.Unmarshal([]byte(ev.ToolArgs), &args)
-		paths, err := l.Repo.List(args.Path, 6, 500)
-		if err != nil {
-			return "", err
-		}
-		b, _ := json.Marshal(paths)
-		return string(b), nil
-	case "read_file":
-		var args struct {
-			Path string `json:"path"`
-		}
-		_ = json.Unmarshal([]byte(ev.ToolArgs), &args)
-		content, bin, _, err := l.Repo.Read(args.Path, 64<<10)
-		if err != nil {
-			return "", err
-		}
-		if bin {
-			return "[binary file]", nil
-		}
-		return content, nil
-	case "search":
-		var args struct {
-			Query string `json:"query"`
-		}
-		_ = json.Unmarshal([]byte(ev.ToolArgs), &args)
-		matches, err := l.Repo.Search(args.Query, ".", 40)
-		if err != nil {
-			return "", err
-		}
-		if len(matches) == 0 {
-			return "no matches", nil
-		}
-		b, _ := json.Marshal(matches)
-		return string(b), nil
-	case "apply_patch":
-		var args struct {
-			Patch string `json:"patch"`
-		}
-		_ = json.Unmarshal([]byte(ev.ToolArgs), &args)
-		return l.Repo.ApplyPatch(args.Patch)
-	case "run_command":
-		var args struct {
-			Command string `json:"command"`
-		}
-		_ = json.Unmarshal([]byte(ev.ToolArgs), &args)
-		timeout := 60 * time.Second
-		if deadline, ok := ctx.Deadline(); ok {
-			timeout = time.Until(deadline)
-		}
-		exit, stdout, stderr, _, _, err := l.Repo.Run(args.Command, "", timeout, tools.DefaultMaxOutput)
-		if err != nil && exit == -1 {
-			return "", err
-		}
-		return fmt.Sprintf("exit=%d\n%s\n%s", exit, stdout, stderr), nil
-	default:
-		return "", fmt.Errorf("unknown tool %q", ev.ToolName)
+	timeout := 60 * time.Second
+	if deadline, ok := ctx.Deadline(); ok {
+		timeout = time.Until(deadline)
 	}
+	result, err := l.Repo.CallTool(ev.ToolName, json.RawMessage(ev.ToolArgs), timeout)
+	return tools.FormatToolResult(result, err)
 }
 
 func truncate(s string, n int) string {
@@ -353,14 +283,4 @@ func truncate(s string, n int) string {
 		return s
 	}
 	return s[:n] + "…"
-}
-
-func ModelFromGuest(m protocol.GuestModel) config.Model {
-	return config.Model{
-		Name:          m.Name,
-		Provider:      m.Provider,
-		Model:         m.Model,
-		CredentialEnv: m.CredentialEnv,
-		BaseURL:       m.BaseURL,
-	}
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -3,18 +3,23 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/AdminTurnedDevOps/ABox/internal/guest/mcp"
+	"github.com/AdminTurnedDevOps/ABox/internal/guest/tools"
 	"github.com/AdminTurnedDevOps/ABox/internal/provider"
 )
 
 func TestBuiltinToolNames(t *testing.T) {
-	tools := BuiltinTools()
-	if len(tools) != 5 {
-		t.Fatalf("want 5 tools, got %d", len(tools))
+	got := BuiltinTools()
+	if len(got) != 5 {
+		t.Fatalf("want 5 tools, got %d", len(got))
+	}
+	if got[0].Name != "list_files" || got[4].Name != "run_command" {
+		t.Fatalf("%q %q", got[0].Name, got[4].Name)
 	}
 }
 
@@ -115,6 +120,21 @@ func TestExecUnknownTool(t *testing.T) {
 	_, err := l.execTool(context.Background(), provider.Event{ToolName: "host_shell"})
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestExecListFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	l := &Loop{Repo: tools.Repo{Root: dir}}
+	out, err := l.execTool(context.Background(), provider.Event{ToolName: "list_files", ToolArgs: `{"path":"."}`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != `["a.txt"]` {
+		t.Fatalf("out=%q", out)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,8 +9,12 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/AdminTurnedDevOps/ABox/internal/vmmconfig"
+	"github.com/AdminTurnedDevOps/ABox/protocol"
 	"gopkg.in/yaml.v3"
 )
+
+const GuestImageName = "abox-guest.raw"
 
 type File struct {
 	Models       []Model      `yaml:"models"`
@@ -59,18 +63,14 @@ type Resources struct {
 
 func Defaults() File {
 	return File{
-		Models: []Model{
-			{Name: "grok-default", Provider: "xai", Model: "grok-4", CredentialEnv: "XAI_API_KEY", BaseURL: "https://api.x.ai/v1"},
-			{Name: "openai-default", Provider: "openai", Model: "gpt-4.1", CredentialEnv: "OPENAI_API_KEY", BaseURL: "https://api.openai.com/v1"},
-			{Name: "claude-default", Provider: "anthropic", Model: "claude-sonnet-4-20250514", CredentialEnv: "ANTHROPIC_API_KEY", BaseURL: "https://api.anthropic.com"},
-		},
+		Models:       defaultModels(),
 		Connectivity: Connectivity{Mode: "direct"},
 		Runtime: Runtime{
 			Isolation: "microvm",
 			Backend:   "libkrun",
 			Network:   "deny-by-default",
 		},
-		Resources: Resources{VCPU: 1, RAMMiB: 768},
+		Resources: Resources{VCPU: vmmconfig.DefaultVCPU, RAMMiB: vmmconfig.DefaultRAMMiB},
 	}
 }
 
@@ -199,7 +199,7 @@ func (s MCPServer) validate() error {
 	if err := validateHTTPSURL("url", s.URL); err != nil {
 		return err
 	}
-	if s.CredentialEnv != "" && !validEnvName(s.CredentialEnv) {
+	if s.CredentialEnv != "" && !ValidEnvName(s.CredentialEnv) {
 		return fmt.Errorf("invalid credential_env %q", s.CredentialEnv)
 	}
 	return nil
@@ -229,7 +229,7 @@ func validateHTTPSURL(field, raw string) error {
 	return nil
 }
 
-func validEnvName(name string) bool {
+func ValidEnvName(name string) bool {
 	if name == "" {
 		return false
 	}
@@ -245,6 +245,61 @@ func validEnvName(name string) bool {
 		}
 	}
 	return true
+}
+
+func (m Model) ToGuest() protocol.GuestModel {
+	return protocol.GuestModel{
+		Name:          m.Name,
+		Provider:      m.Provider,
+		Model:         m.Model,
+		CredentialEnv: m.CredentialEnv,
+		BaseURL:       m.BaseURL,
+	}
+}
+
+func ModelFromGuest(m protocol.GuestModel) Model {
+	return Model{
+		Name:          m.Name,
+		Provider:      m.Provider,
+		Model:         m.Model,
+		CredentialEnv: m.CredentialEnv,
+		BaseURL:       m.BaseURL,
+	}
+}
+
+func (r Resources) Resolved() (vcpu, ram int) {
+	vcpu, ram = r.VCPU, r.RAMMiB
+	if vcpu == 0 {
+		vcpu = vmmconfig.DefaultVCPU
+	}
+	if ram == 0 {
+		ram = vmmconfig.DefaultRAMMiB
+	}
+	return
+}
+
+func (c File) SecretsFromEnv() map[string]string {
+	out := map[string]string{}
+	for _, env := range ProviderCredentialEnvs() {
+		if v := os.Getenv(env); v != "" {
+			out[env] = v
+		}
+	}
+	servers, err := c.ResolvedMCPServers()
+	if err != nil {
+		return out
+	}
+	for _, s := range servers {
+		name := TokenEnv(s)
+		if v := os.Getenv(name); v != "" {
+			out[name] = v
+		}
+	}
+	return out
+}
+
+func GuestImagePath() string {
+	return filepath.Join(ImageDir(), GuestImageName)
 }
 
 // ResolvedMCPServers returns the MCP URLs the guest may dial.
@@ -382,13 +437,13 @@ func CacheDir() string {
 
 func ImageDir() string {
 	modern := filepath.Join(Dir(), "images")
-	if exists(filepath.Join(modern, "abox-guest.raw")) {
+	if exists(filepath.Join(modern, GuestImageName)) {
 		return modern
 	}
 	home := homeDir()
 	if home != "" {
 		legacy := filepath.Join(home, "Library", "Caches", "ABox", "images")
-		if exists(filepath.Join(legacy, "abox-guest.raw")) {
+		if exists(filepath.Join(legacy, GuestImageName)) {
 			return legacy
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,55 @@ import (
 	"testing"
 )
 
+func TestModelGuestRoundTrip(t *testing.T) {
+	orig := Model{Name: "grok-default", Provider: "xai", Model: "grok-4", CredentialEnv: "XAI_API_KEY", BaseURL: "https://api.x.ai/v1"}
+	got := ModelFromGuest(orig.ToGuest())
+	if got != orig {
+		t.Fatalf("got %+v want %+v", got, orig)
+	}
+}
+
+func TestValidEnvName(t *testing.T) {
+	if !ValidEnvName("XAI_API_KEY") || !ValidEnvName("A1") || ValidEnvName("1A") || ValidEnvName("xai") || ValidEnvName("") {
+		t.Fatal("ValidEnvName mismatch")
+	}
+}
+
+func TestDefaultProvidersDriveDefaults(t *testing.T) {
+	cfg := Defaults()
+	ps := DefaultProviders()
+	if len(cfg.Models) != len(ps) {
+		t.Fatalf("models %d providers %d", len(cfg.Models), len(ps))
+	}
+	for i, p := range ps {
+		if cfg.Models[i] != p.ModelConfig() {
+			t.Fatalf("model[%d]=%+v want %+v", i, cfg.Models[i], p.ModelConfig())
+		}
+	}
+	if cfg.Resources.VCPU != 1 || cfg.Resources.RAMMiB != 768 {
+		t.Fatalf("resources %+v", cfg.Resources)
+	}
+	vcpu, ram := Resources{}.Resolved()
+	if vcpu != 1 || ram != 768 {
+		t.Fatalf("resolved %d %d", vcpu, ram)
+	}
+}
+
+func TestSecretsFromEnv(t *testing.T) {
+	t.Setenv("XAI_API_KEY", "xk")
+	t.Setenv("OPENAI_API_KEY", "")
+	c := Defaults()
+	c.MCPServers = []MCPServer{{Name: "gh", URL: "https://api.githubcopilot.com/mcp/", CredentialEnv: "ABOX_MCP_GH_TOKEN"}}
+	t.Setenv("ABOX_MCP_GH_TOKEN", "mt")
+	got := c.SecretsFromEnv()
+	if got["XAI_API_KEY"] != "xk" || got["ABOX_MCP_GH_TOKEN"] != "mt" {
+		t.Fatalf("%#v", got)
+	}
+	if _, ok := got["OPENAI_API_KEY"]; ok {
+		t.Fatalf("empty openai key leaked: %#v", got)
+	}
+}
+
 func TestValidateRejectsUnknownMode(t *testing.T) {
 	c := Defaults()
 	c.Connectivity.Mode = "wide-open"

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -1,0 +1,47 @@
+package config
+
+// ProviderProfile is one built-in model picker row and default config.Models entry.
+type ProviderProfile struct {
+	Label    string
+	Name     string
+	Provider string
+	Model    string
+	Env      string
+	BaseURL  string
+}
+
+func DefaultProviders() []ProviderProfile {
+	return []ProviderProfile{
+		{Label: "Grok (xAI)", Name: "grok-default", Provider: "xai", Model: "grok-4", Env: "XAI_API_KEY", BaseURL: "https://api.x.ai/v1"},
+		{Label: "OpenAI", Name: "openai-default", Provider: "openai", Model: "gpt-4.1", Env: "OPENAI_API_KEY", BaseURL: "https://api.openai.com/v1"},
+		{Label: "Anthropic", Name: "claude-default", Provider: "anthropic", Model: "claude-sonnet-4-20250514", Env: "ANTHROPIC_API_KEY", BaseURL: "https://api.anthropic.com"},
+	}
+}
+
+func (p ProviderProfile) ModelConfig() Model {
+	return Model{
+		Name:          p.Name,
+		Provider:      p.Provider,
+		Model:         p.Model,
+		CredentialEnv: p.Env,
+		BaseURL:       p.BaseURL,
+	}
+}
+
+func ProviderCredentialEnvs() []string {
+	ps := DefaultProviders()
+	out := make([]string, len(ps))
+	for i, p := range ps {
+		out[i] = p.Env
+	}
+	return out
+}
+
+func defaultModels() []Model {
+	ps := DefaultProviders()
+	out := make([]Model, len(ps))
+	for i, p := range ps {
+		out[i] = p.ModelConfig()
+	}
+	return out
+}

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -11,7 +11,9 @@ import (
 	"github.com/AdminTurnedDevOps/ABox/internal/config"
 )
 
-var preferredOrder = []string{"XAI_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"}
+func preferredOrder() []string {
+	return config.ProviderCredentialEnvs()
+}
 
 func Path() string {
 	return filepath.Join(config.AppSupportDir(), "credentials.env")
@@ -50,7 +52,7 @@ func Save(envName, value string) error {
 	if envName == "" {
 		return fmt.Errorf("empty credential name")
 	}
-	if !validCredName(envName) {
+	if !config.ValidEnvName(envName) {
 		return fmt.Errorf("invalid credential name %q", envName)
 	}
 	value = strings.TrimSpace(value)
@@ -77,7 +79,7 @@ func Save(envName, value string) error {
 			written[name] = struct{}{}
 		}
 	}
-	for _, name := range preferredOrder {
+	for _, name := range preferredOrder() {
 		write(name)
 	}
 	var rest []string
@@ -118,24 +120,6 @@ func ApplyToEnv() error {
 		}
 	}
 	return nil
-}
-
-func validCredName(name string) bool {
-	if name == "" {
-		return false
-	}
-	for i, r := range name {
-		switch {
-		case r >= 'A' && r <= 'Z', r == '_':
-		case r >= '0' && r <= '9':
-			if i == 0 {
-				return false
-			}
-		default:
-			return false
-		}
-	}
-	return true
 }
 
 func SetEnv(envName, value string) {

--- a/internal/guest/tools/builtins.go
+++ b/internal/guest/tools/builtins.go
@@ -1,0 +1,205 @@
+package tools
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/AdminTurnedDevOps/ABox/protocol"
+)
+
+const (
+	ListFiles  = "list_files"
+	ReadFile   = "read_file"
+	Search     = "search"
+	ApplyPatch = "apply_patch"
+	RunCommand = "run_command"
+
+	AgentListDepth   = 6
+	AgentListLimit   = 500
+	AgentReadMax     = 64 << 10
+	AgentSearchPath  = "."
+	AgentSearchLimit = 40
+)
+
+type Spec struct {
+	Name        string
+	Description string
+	Parameters  map[string]any
+}
+
+func BuiltinSpecs() []Spec {
+	obj := func(props map[string]any) map[string]any {
+		return map[string]any{"type": "object", "properties": props}
+	}
+	return []Spec{
+		{Name: ListFiles, Description: "List paths in the guest repository", Parameters: obj(map[string]any{
+			"path": map[string]any{"type": "string"},
+		})},
+		{Name: ReadFile, Description: "Read a file in the guest repository", Parameters: obj(map[string]any{
+			"path": map[string]any{"type": "string"},
+		})},
+		{Name: Search, Description: "Search the guest repository", Parameters: obj(map[string]any{
+			"query": map[string]any{"type": "string"},
+		})},
+		{Name: ApplyPatch, Description: "Apply a unified diff in the guest repository", Parameters: obj(map[string]any{
+			"patch": map[string]any{"type": "string"},
+		})},
+		{Name: RunCommand, Description: "Run a shell command in the guest", Parameters: obj(map[string]any{
+			"command": map[string]any{"type": "string"},
+		})},
+	}
+}
+
+func IsBuiltin(name string) bool {
+	for _, s := range BuiltinSpecs() {
+		if s.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// CallBuiltin runs a host-guest RPC builtin. Empty params are an error.
+func (r Repo) CallBuiltin(name string, raw json.RawMessage, timeout time.Duration) (any, error) {
+	return r.call(name, raw, timeout, false)
+}
+
+// CallTool runs a model-facing builtin. Empty or invalid JSON uses zero params plus agent defaults.
+func (r Repo) CallTool(name string, raw json.RawMessage, timeout time.Duration) (any, error) {
+	return r.call(name, raw, timeout, true)
+}
+
+func (r Repo) call(name string, raw json.RawMessage, timeout time.Duration, agent bool) (any, error) {
+	switch name {
+	case ListFiles:
+		p, err := unmarshalParams[protocol.ListFilesParams](raw, agent)
+		if err != nil {
+			return nil, err
+		}
+		if agent {
+			if p.Depth == 0 {
+				p.Depth = AgentListDepth
+			}
+			if p.Limit == 0 {
+				p.Limit = AgentListLimit
+			}
+		}
+		paths, err := r.List(p.Path, p.Depth, p.Limit)
+		if err != nil {
+			return nil, err
+		}
+		return protocol.ListFilesResult{Paths: paths}, nil
+	case ReadFile:
+		p, err := unmarshalParams[protocol.ReadFileParams](raw, agent)
+		if err != nil {
+			return nil, err
+		}
+		if agent && p.MaxBytes == 0 {
+			p.MaxBytes = AgentReadMax
+		}
+		content, bin, trunc, err := r.Read(p.Path, p.MaxBytes)
+		if err != nil {
+			return nil, err
+		}
+		return protocol.ReadFileResult{Content: content, Binary: bin, Trunc: trunc}, nil
+	case Search:
+		p, err := unmarshalParams[protocol.SearchParams](raw, agent)
+		if err != nil {
+			return nil, err
+		}
+		if agent {
+			if p.Path == "" {
+				p.Path = AgentSearchPath
+			}
+			if p.Limit == 0 {
+				p.Limit = AgentSearchLimit
+			}
+		}
+		matches, err := r.Search(p.Query, p.Path, p.Limit)
+		if err != nil {
+			return nil, err
+		}
+		return protocol.SearchResult{Matches: matches}, nil
+	case ApplyPatch:
+		p, err := unmarshalParams[protocol.ApplyPatchParams](raw, agent)
+		if err != nil {
+			return nil, err
+		}
+		output, err := r.ApplyPatch(p.Patch)
+		return protocol.ApplyPatchResult{OK: err == nil, Output: output}, err
+	case RunCommand:
+		p, err := unmarshalParams[protocol.RunCommandParams](raw, agent)
+		if err != nil {
+			return nil, err
+		}
+		to := timeout
+		if to <= 0 && p.Timeout > 0 {
+			to = time.Duration(p.Timeout) * time.Second
+		}
+		exit, stdout, stderr, dur, trunc, err := r.Run(p.Command, p.WorkDir, to, DefaultMaxOutput)
+		return protocol.RunCommandResult{
+			ExitCode: exit, Stdout: stdout, Stderr: stderr, Duration: dur.String(), Trunc: trunc,
+		}, err
+	default:
+		return nil, fmt.Errorf("unknown tool %q", name)
+	}
+}
+
+func FormatToolResult(result any, err error) (string, error) {
+	switch v := result.(type) {
+	case protocol.ListFilesResult:
+		if err != nil {
+			return "", err
+		}
+		b, _ := json.Marshal(v.Paths)
+		return string(b), nil
+	case protocol.ReadFileResult:
+		if err != nil {
+			return "", err
+		}
+		if v.Binary {
+			return "[binary file]", nil
+		}
+		return v.Content, nil
+	case protocol.SearchResult:
+		if err != nil {
+			return "", err
+		}
+		if len(v.Matches) == 0 {
+			return "no matches", nil
+		}
+		b, _ := json.Marshal(v.Matches)
+		return string(b), nil
+	case protocol.ApplyPatchResult:
+		return v.Output, err
+	case protocol.RunCommandResult:
+		if err != nil && v.ExitCode == -1 {
+			return "", err
+		}
+		return fmt.Sprintf("exit=%d\n%s\n%s", v.ExitCode, v.Stdout, v.Stderr), nil
+	default:
+		if err != nil {
+			return "", err
+		}
+		return "", fmt.Errorf("unknown tool result %T", result)
+	}
+}
+
+func unmarshalParams[T any](raw json.RawMessage, lenient bool) (T, error) {
+	var v T
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		if lenient {
+			return v, nil
+		}
+		return v, fmt.Errorf("empty params")
+	}
+	err := json.Unmarshal(raw, &v)
+	if err != nil && lenient {
+		var zero T
+		return zero, nil
+	}
+	return v, err
+}

--- a/internal/guest/tools/tools_test.go
+++ b/internal/guest/tools/tools_test.go
@@ -1,10 +1,62 @@
 package tools
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/AdminTurnedDevOps/ABox/protocol"
 )
+
+func TestBuiltinSpecsCount(t *testing.T) {
+	if n := len(BuiltinSpecs()); n != 5 {
+		t.Fatalf("want 5 builtins, got %d", n)
+	}
+	for _, s := range BuiltinSpecs() {
+		if !IsBuiltin(s.Name) {
+			t.Fatalf("%q not IsBuiltin", s.Name)
+		}
+	}
+	if IsBuiltin("host_shell") {
+		t.Fatal("host_shell must not be builtin")
+	}
+}
+
+func TestCallBuiltinAndTool(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r := Repo{Root: dir}
+	raw, _ := json.Marshal(protocol.ListFilesParams{Path: ".", Depth: 4, Limit: 50})
+	got, err := r.CallBuiltin(ListFiles, raw, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := got.(protocol.ListFilesResult)
+	if len(res.Paths) != 1 || res.Paths[0] != "a.txt" {
+		t.Fatalf("%#v", res)
+	}
+	if _, err := r.CallBuiltin(ListFiles, nil, 0); err == nil {
+		t.Fatal("empty rpc params should fail")
+	}
+	out, err := FormatToolResult(r.CallTool(ListFiles, []byte(`{"path":"."}`), 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != `["a.txt"]` {
+		t.Fatalf("tool list %q", out)
+	}
+	text, err := FormatToolResult(r.CallTool(ReadFile, []byte(`{"path":"a.txt"}`), 0))
+	if err != nil || text != "hello" {
+		t.Fatalf("read %q err=%v", text, err)
+	}
+	none, err := FormatToolResult(r.CallTool(Search, []byte(`{"query":"zzz"}`), 0))
+	if err != nil || none != "no matches" {
+		t.Fatalf("search %q err=%v", none, err)
+	}
+}
 
 func TestRejectTraversal(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -30,7 +30,7 @@ type Sandbox struct {
 
 func Prepare(sess *session.Session, imagePath string, model config.Model, secrets map[string]string, mcpServers []config.MCPServer, resume bool) error {
 	if imagePath == "" {
-		imagePath = filepath.Join(config.ImageDir(), "abox-guest.raw")
+		imagePath = config.GuestImagePath()
 	}
 	if resume {
 		if _, err := os.Stat(sess.RootDisk()); err != nil {
@@ -95,7 +95,7 @@ func Start(ctx context.Context, sess *session.Session, vmmPath string, vcpu int,
 		ConfigDisk: sess.ConfigDisk(),
 		RPCSocket:  sess.RPCSocket(),
 		VsockPort:  protocol.RPCPort,
-		ExecPath:   "/usr/local/bin/abox-guest",
+		ExecPath:   vmmconfig.DefaultExecPath,
 		ConsoleLog: sess.ConsoleLog(),
 	}
 	payload, err := json.Marshal(cfg)
@@ -263,13 +263,7 @@ func (s *Sandbox) SetMCPTokens(ctx context.Context, secrets map[string]string) e
 
 func (s *Sandbox) SetModel(ctx context.Context, model config.Model, secrets map[string]string) error {
 	return s.Call(ctx, "set_model", protocol.SetModelParams{
-		Model: protocol.GuestModel{
-			Name:          model.Name,
-			Provider:      model.Provider,
-			Model:         model.Model,
-			CredentialEnv: model.CredentialEnv,
-			BaseURL:       model.BaseURL,
-		},
+		Model:   model.ToGuest(),
 		Secrets: secrets,
 	}, nil)
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -186,14 +186,8 @@ func (s *Session) WriteGuestConfig(model config.Model, secrets map[string]string
 		SessionID:  s.ID,
 		Capability: s.Capability,
 		VsockPort:  protocol.RPCPort,
-		RepoDir:    "/work/repo",
-		Model: protocol.GuestModel{
-			Name:          model.Name,
-			Provider:      model.Provider,
-			Model:         model.Model,
-			CredentialEnv: model.CredentialEnv,
-			BaseURL:       model.BaseURL,
-		},
+		RepoDir:    protocol.GuestRepoDir,
+		Model:      model.ToGuest(),
 		Secrets:    secrets,
 		MCPServers: gs,
 	}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -18,19 +18,8 @@ var slashCommands = []slashCmd{
 	{Name: "/help", Help: "List slash commands"},
 }
 
-type providerChoice struct {
-	Label    string
-	Provider string
-	Profile  string
-	Env      string
-}
-
-func providerChoices() []providerChoice {
-	return []providerChoice{
-		{Label: "Grok (xAI)", Provider: "xai", Profile: "grok-default", Env: "XAI_API_KEY"},
-		{Label: "OpenAI", Provider: "openai", Profile: "openai-default", Env: "OPENAI_API_KEY"},
-		{Label: "Anthropic", Provider: "anthropic", Profile: "claude-default", Env: "ANTHROPIC_API_KEY"},
-	}
+func providerChoices() []config.ProviderProfile {
+	return config.DefaultProviders()
 }
 
 func filterSlash(q string) []slashCmd {
@@ -64,18 +53,13 @@ func applyMCPKey(server config.MCPServer, key string) (string, error) {
 	return env, nil
 }
 
-func applyProviderKey(cfg config.File, choice providerChoice, key string) (config.Model, error) {
+func applyProviderKey(cfg config.File, choice config.ProviderProfile, key string) (config.Model, error) {
 	if err := credentials.Save(choice.Env, key); err != nil {
 		return config.Model{}, err
 	}
 	credentials.SetEnv(choice.Env, key)
-	if m, ok := cfg.ModelNamed(choice.Profile); ok {
+	if m, ok := cfg.ModelNamed(choice.Name); ok {
 		return m, nil
 	}
-	return config.Model{
-		Name:          choice.Profile,
-		Provider:      choice.Provider,
-		Model:         choice.Profile,
-		CredentialEnv: choice.Env,
-	}, nil
+	return choice.ModelConfig(), nil
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -37,7 +37,7 @@ type model struct {
 	mode           uiMode
 	slashSel       int
 	provSel        int
-	provPick       providerChoice
+	provPick       config.ProviderProfile
 	mcpSel         int
 	mcpPick        config.MCPServer
 	log            []string

--- a/internal/vmmconfig/vmmconfig.go
+++ b/internal/vmmconfig/vmmconfig.go
@@ -1,6 +1,14 @@
 // Package vmmconfig is the JSON stdin contract from the supervisor to abox-vmm.
 package vmmconfig
 
+import "github.com/AdminTurnedDevOps/ABox/protocol"
+
+const (
+	DefaultVCPU     = 1
+	DefaultRAMMiB   = 768
+	DefaultExecPath = "/usr/local/bin/abox-guest"
+)
+
 // Config is the validated blob the host supervisor sends to abox-vmm on stdin.
 type Config struct {
 	VCPU       uint8  `json:"vcpu"`
@@ -11,4 +19,19 @@ type Config struct {
 	VsockPort  uint32 `json:"vsock_port"`
 	ExecPath   string `json:"exec_path"`
 	ConsoleLog string `json:"console_log"`
+}
+
+func (c *Config) ApplyDefaults() {
+	if c.VCPU == 0 {
+		c.VCPU = DefaultVCPU
+	}
+	if c.RAMMiB == 0 {
+		c.RAMMiB = DefaultRAMMiB
+	}
+	if c.VsockPort == 0 {
+		c.VsockPort = protocol.RPCPort
+	}
+	if c.ExecPath == "" {
+		c.ExecPath = DefaultExecPath
+	}
 }

--- a/internal/vmmconfig/vmmconfig_test.go
+++ b/internal/vmmconfig/vmmconfig_test.go
@@ -3,7 +3,17 @@ package vmmconfig
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/AdminTurnedDevOps/ABox/protocol"
 )
+
+func TestApplyDefaults(t *testing.T) {
+	var cfg Config
+	cfg.ApplyDefaults()
+	if cfg.VCPU != DefaultVCPU || cfg.RAMMiB != DefaultRAMMiB || cfg.ExecPath != DefaultExecPath || cfg.VsockPort != protocol.RPCPort {
+		t.Fatalf("%+v", cfg)
+	}
+}
 
 func TestConfigJSONRoundTrip(t *testing.T) {
 	orig := Config{

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -15,6 +15,7 @@ const (
 	MaxArchiveChunk = 256 << 10
 	MaxHistoryBytes = 256 << 10
 	RPCPort         = 1024
+	GuestRepoDir    = "/work/repo"
 )
 
 // Frame is a length-prefixed JSON message.
@@ -48,13 +49,17 @@ type HelloParams struct {
 	History    []HistoryLine `json:"history,omitempty"`
 }
 
-type HistoryLine struct {
+// AgentEvent is a live or stored agent output line.
+type AgentEvent struct {
 	Kind   string `json:"kind"`
 	Text   string `json:"text,omitempty"`
 	Tool   string `json:"tool,omitempty"`
 	Status string `json:"status,omitempty"`
 	Err    string `json:"err,omitempty"`
 }
+
+// HistoryLine is persisted AgentEvent JSON (hello, get_context, transcripts).
+type HistoryLine = AgentEvent
 
 type GetContextResult struct {
 	History []HistoryLine `json:"history"`
@@ -172,14 +177,6 @@ type GuestModel struct {
 
 type UserTurnParams struct {
 	Text string `json:"text"`
-}
-
-type AgentEvent struct {
-	Kind   string `json:"kind"`
-	Text   string `json:"text,omitempty"`
-	Tool   string `json:"tool,omitempty"`
-	Status string `json:"status,omitempty"`
-	Err    string `json:"err,omitempty"`
 }
 
 type SetModelParams struct {

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -32,6 +32,14 @@ func TestTrimHistoryKeepsNewest(t *testing.T) {
 	}
 }
 
+func TestHistoryLineAliasesAgentEvent(t *testing.T) {
+	ev := AgentEvent{Kind: "text", Text: "hi", Tool: "search", Status: "ok", Err: "e"}
+	var line HistoryLine = ev
+	if line != ev {
+		t.Fatalf("got %+v want %+v", line, ev)
+	}
+}
+
 func TestRejectOversizedFrame(t *testing.T) {
 	var buf bytes.Buffer
 	buf.Write([]byte{0xff, 0xff, 0xff, 0xff})


### PR DESCRIPTION
1. Model conversion: `config.Model.ToGuest()` / `config.ModelFromGuest()` is the only host YAML ↔ guest JSON mapping; session config disk, set_model, and the guest agent all use it.
2. History = events: `protocol.HistoryLine `is an alias of `protocol.AgentEvent`, so resume, `get_context`, and live TUI events share one JSON shape.
3. Env-name check: `config.ValidEnvName `is the single alphabet for MCP `credential_env` and `credentials.Save`.
4. Defaults catalog: One provider table plus vmmconfig resource/exec defaults, protocol.GuestRepoDir, and config.GuestImagePath / SecretsFromEnv() replace the scattered 1/768, three API keys, /work/repo, and golden-image strings.
5. Builtin tools: tools.BuiltinSpecs plus CallBuiltin / CallTool is the registry; guest RPC handle and the model execTool path both go through it, so a sixth tool is one spec and one switch.